### PR TITLE
v2.1.2 version locked aws ruby sdk gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 chef\_cfn changelog
 ===================
 
+v2.1.2
+------
+* Version-locked aws-ruby-sdk to '~> v2.10.98'
+
 v2.1.1
 ------
 * Add missing cloudwatch configuration attributes

--- a/attributes/cfn-cloudwatch.rb
+++ b/attributes/cfn-cloudwatch.rb
@@ -1,4 +1,4 @@
-node['cfn']['cloudwatch'].tap do |config|
+default['cfn']['cloudwatch'].tap do |config|
   config['report_failure'] = true
   config['report_success'] = false
   config['report_cookbooks'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Chef integration with AWS cloudformation'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url       'https://github.com/JonathanSerafini/chef-cfn/issues'
 source_url       'https://github.com/JonathanSerafini/chef-cfn'
-version          '2.1.1'
+version          '2.1.2'
 
 depends 'chef_handler'
 depends 'ohai', '>= 4.0.0'

--- a/recipes/ohai.rb
+++ b/recipes/ohai.rb
@@ -1,7 +1,7 @@
 # Install dependencies
 #
 chef_gem 'aws-sdk' do
-  version '~> 2.10'
+  version '~> 2'
   compile_time true if respond_to?(:compile_time)
 end
 

--- a/recipes/ohai.rb
+++ b/recipes/ohai.rb
@@ -1,6 +1,7 @@
 # Install dependencies
 #
 chef_gem 'aws-sdk' do
+  version '~> 2.10'
   compile_time true if respond_to?(:compile_time)
 end
 


### PR DESCRIPTION
- Fixed aws-ruby-sdk issue by version locking to `~> 2` (Fixes: https://github.com/JonathanSerafini/chef-cfn/issues/4)
- Fixed cloudwatch attributes issue the same way as: https://github.com/JonathanSerafini/chef-cfn/pull/3